### PR TITLE
Add file upload handler with FSM and comprehensive tests

### DIFF
--- a/bot/handlers/files.py
+++ b/bot/handlers/files.py
@@ -1,0 +1,76 @@
+from aiogram import Router, F
+from aiogram.types import Message
+from aiogram.filters import Command
+from aiogram.fsm.context import FSMContext
+
+from ..states import UploadState
+
+router = Router()
+
+# Захардкоженные настройки (позже можно вынести в конфиг)
+MAX_FILE_SIZE = 100 * 1024 * 1024  # 100 MB
+ALLOWED_EXTENSIONS = {".json", ".html", ".zip"}
+
+
+@router.message(F.document)
+async def handle_document(message: Message, state: FSMContext) -> None:
+    """Обработчик документов."""
+    # Устанавливаем состояние, если его еще нет
+    current_state = await state.get_state()
+    if current_state is None:
+        await state.set_state(UploadState.waiting_files)
+
+    document = message.document
+
+    # Проверка размера файла
+    if document.file_size and document.file_size > MAX_FILE_SIZE:
+        await message.answer(
+            f"❌ Файл слишком большой. Максимальный размер: {MAX_FILE_SIZE / (1024 * 1024):.0f} MB"
+        )
+        return
+
+    # Проверка расширения файла
+    file_name = document.file_name or ""
+    file_extension = None
+    for ext in ALLOWED_EXTENSIONS:
+        if file_name.lower().endswith(ext):
+            file_extension = ext
+            break
+
+    if not file_extension:
+        allowed_str = ", ".join(ALLOWED_EXTENSIONS)
+        await message.answer(
+            f"❌ Неподдерживаемый формат файла. Разрешены: {allowed_str}"
+        )
+        return
+
+    # Получаем текущий список файлов из состояния
+    data = await state.get_data()
+    files = data.get("files", [])
+
+    # Добавляем метаданные файла
+    file_metadata = {
+        "file_id": document.file_id,
+        "file_name": file_name,
+        "file_size": document.file_size,
+        "file_extension": file_extension,
+    }
+    files.append(file_metadata)
+
+    # Сохраняем обновленный список в состояние
+    await state.update_data(files=files)
+
+    # Отвечаем пользователю
+    count = len(files)
+    await message.answer(
+        f"✅ Файл принят, сейчас в очереди {count} файл(ов). "
+        "Используйте /process когда будете готовы."
+    )
+
+
+@router.message(Command("reset"))
+async def cmd_reset(message: Message, state: FSMContext) -> None:
+    """Команда для очистки состояния и очереди файлов."""
+    await state.clear()
+    await message.answer("🔄 Очередь файлов очищена.")
+

--- a/bot/main.py
+++ b/bot/main.py
@@ -5,7 +5,7 @@ from aiogram import Bot, Dispatcher
 from aiogram.fsm.storage.memory import MemoryStorage
 
 from .config import get_settings
-from .handlers import start
+from .handlers import start, files
 
 
 async def main() -> None:
@@ -19,8 +19,9 @@ async def main() -> None:
     bot = Bot(token=settings.bot_token)
     dp = Dispatcher(storage=MemoryStorage())
 
-    # Подключаем только роутер Dev1
+    # Подключаем роутеры
     dp.include_router(start.router)
+    dp.include_router(files.router)
 
     logging.info("Starting bot polling...")
     await dp.start_polling(bot)

--- a/bot/states.py
+++ b/bot/states.py
@@ -1,0 +1,6 @@
+from aiogram.fsm.state import State, StatesGroup
+
+
+class UploadState(StatesGroup):
+    waiting_files = State()
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,7 @@ aiogram==3.13.1
 pydantic==2.9.2
 openpyxl==3.1.5
 python-dotenv==1.0.1
+
+# Testing dependencies
+pytest==8.3.4
+pytest-asyncio==0.24.0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+# Tests package
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,117 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from aiogram.types import Message, User, Chat, Document
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.storage.memory import MemoryStorage
+
+from bot.states import UploadState
+
+
+@pytest.fixture
+def memory_storage():
+    """Фикстура для MemoryStorage."""
+    return MemoryStorage()
+
+
+@pytest.fixture
+def fsm_context(memory_storage):
+    """Фикстура для FSMContext."""
+    from aiogram import Bot
+    bot = Bot(token="123:ABC")
+    return FSMContext(
+        storage=memory_storage,
+        key=FSMContext.key(bot=bot, user_id=123, chat_id=123)
+    )
+
+
+@pytest.fixture
+def user():
+    """Фикстура для пользователя."""
+    return User(
+        id=123,
+        is_bot=False,
+        first_name="Test",
+        username="testuser"
+    )
+
+
+@pytest.fixture
+def chat():
+    """Фикстура для чата."""
+    return Chat(id=123, type="private")
+
+
+@pytest.fixture
+def message(user, chat):
+    """Базовая фикстура для сообщения."""
+    msg = Message(
+        message_id=1,
+        date=None,
+        chat=chat,
+        from_user=user
+    )
+    msg.answer = AsyncMock()
+    return msg
+
+
+@pytest.fixture
+def document_json():
+    """Фикстура для документа JSON."""
+    return Document(
+        file_id="test_file_id_json",
+        file_unique_id="test_unique_id_json",
+        file_name="export.json",
+        file_size=1024 * 1024,  # 1 MB
+    )
+
+
+@pytest.fixture
+def document_html():
+    """Фикстура для документа HTML."""
+    return Document(
+        file_id="test_file_id_html",
+        file_unique_id="test_unique_id_html",
+        file_name="export.html",
+        file_size=2 * 1024 * 1024,  # 2 MB
+    )
+
+
+@pytest.fixture
+def document_zip():
+    """Фикстура для документа ZIP."""
+    return Document(
+        file_id="test_file_id_zip",
+        file_unique_id="test_unique_id_zip",
+        file_name="export.zip",
+        file_size=5 * 1024 * 1024,  # 5 MB
+    )
+
+
+@pytest.fixture
+def document_large():
+    """Фикстура для большого документа."""
+    return Document(
+        file_id="test_file_id_large",
+        file_unique_id="test_unique_id_large",
+        file_name="export.json",
+        file_size=101 * 1024 * 1024,  # 101 MB (превышает лимит)
+    )
+
+
+@pytest.fixture
+def document_invalid_extension():
+    """Фикстура для документа с неподдерживаемым расширением."""
+    return Document(
+        file_id="test_file_id_invalid",
+        file_unique_id="test_unique_id_invalid",
+        file_name="export.txt",
+        file_size=1024,  # 1 KB
+    )
+
+
+@pytest.fixture
+def message_with_document(message, document_json):
+    """Сообщение с документом."""
+    message.document = document_json
+    return message
+

--- a/tests/test_files_handler.py
+++ b/tests/test_files_handler.py
@@ -1,0 +1,265 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from aiogram.types import Message, Document
+from aiogram.fsm.context import FSMContext
+
+from bot.handlers.files import handle_document, cmd_reset, MAX_FILE_SIZE, ALLOWED_EXTENSIONS
+from bot.states import UploadState
+
+
+class TestHandleDocument:
+    """Тесты для обработчика документов."""
+
+    @pytest.mark.asyncio
+    async def test_handle_document_success_json(self, message_with_document, fsm_context):
+        """Тест успешной обработки JSON файла."""
+        # Вызываем обработчик
+        await handle_document(message_with_document, fsm_context)
+
+        # Проверяем, что состояние установлено
+        state = await fsm_context.get_state()
+        assert state == UploadState.waiting_files
+
+        # Проверяем, что файл сохранен в состоянии
+        data = await fsm_context.get_data()
+        assert "files" in data
+        assert len(data["files"]) == 1
+        assert data["files"][0]["file_id"] == "test_file_id_json"
+        assert data["files"][0]["file_name"] == "export.json"
+        assert data["files"][0]["file_extension"] == ".json"
+
+        # Проверяем, что отправлен ответ
+        message_with_document.answer.assert_called_once()
+        call_args = message_with_document.answer.call_args[0][0]
+        assert "✅ Файл принят" in call_args
+        assert "1 файл(ов)" in call_args
+
+    @pytest.mark.asyncio
+    async def test_handle_document_success_html(self, message, document_html, fsm_context):
+        """Тест успешной обработки HTML файла."""
+        message.document = document_html
+        message.answer = AsyncMock()
+
+        await handle_document(message, fsm_context)
+
+        data = await fsm_context.get_data()
+        assert len(data["files"]) == 1
+        assert data["files"][0]["file_extension"] == ".html"
+        assert data["files"][0]["file_name"] == "export.html"
+
+    @pytest.mark.asyncio
+    async def test_handle_document_success_zip(self, message, document_zip, fsm_context):
+        """Тест успешной обработки ZIP файла."""
+        message.document = document_zip
+        message.answer = AsyncMock()
+
+        await handle_document(message, fsm_context)
+
+        data = await fsm_context.get_data()
+        assert len(data["files"]) == 1
+        assert data["files"][0]["file_extension"] == ".zip"
+        assert data["files"][0]["file_name"] == "export.zip"
+
+    @pytest.mark.asyncio
+    async def test_handle_document_multiple_files(self, message, document_json, document_html, fsm_context):
+        """Тест обработки нескольких файлов подряд."""
+        # Первый файл
+        message.document = document_json
+        message.answer = AsyncMock()
+        await handle_document(message, fsm_context)
+
+        # Второй файл
+        message.document = document_html
+        message.answer = AsyncMock()
+        await handle_document(message, fsm_context)
+
+        # Проверяем, что оба файла сохранены
+        data = await fsm_context.get_data()
+        assert len(data["files"]) == 2
+        assert data["files"][0]["file_extension"] == ".json"
+        assert data["files"][1]["file_extension"] == ".html"
+
+        # Проверяем, что во втором ответе указано 2 файла
+        call_args = message.answer.call_args[0][0]
+        assert "2 файл(ов)" in call_args
+
+    @pytest.mark.asyncio
+    async def test_handle_document_file_too_large(self, message, document_large, fsm_context):
+        """Тест отклонения файла из-за превышения размера."""
+        message.document = document_large
+        message.answer = AsyncMock()
+
+        await handle_document(message, fsm_context)
+
+        # Проверяем, что файл не сохранен
+        data = await fsm_context.get_data()
+        files = data.get("files", [])
+        assert len(files) == 0
+
+        # Проверяем сообщение об ошибке
+        message.answer.assert_called_once()
+        call_args = message.answer.call_args[0][0]
+        assert "❌ Файл слишком большой" in call_args
+        assert f"{MAX_FILE_SIZE / (1024 * 1024):.0f} MB" in call_args
+
+    @pytest.mark.asyncio
+    async def test_handle_document_invalid_extension(self, message, document_invalid_extension, fsm_context):
+        """Тест отклонения файла с неподдерживаемым расширением."""
+        message.document = document_invalid_extension
+        message.answer = AsyncMock()
+
+        await handle_document(message, fsm_context)
+
+        # Проверяем, что файл не сохранен
+        data = await fsm_context.get_data()
+        files = data.get("files", [])
+        assert len(files) == 0
+
+        # Проверяем сообщение об ошибке
+        message.answer.assert_called_once()
+        call_args = message.answer.call_args[0][0]
+        assert "❌ Неподдерживаемый формат файла" in call_args
+        # Проверяем, что в сообщении указаны разрешенные расширения
+        for ext in ALLOWED_EXTENSIONS:
+            assert ext in call_args
+
+    @pytest.mark.asyncio
+    async def test_handle_document_case_insensitive_extension(self, message, fsm_context):
+        """Тест обработки файла с расширением в верхнем регистре."""
+        document = Document(
+            file_id="test_file_id",
+            file_unique_id="test_unique_id",
+            file_name="export.JSON",  # Верхний регистр
+            file_size=1024,
+        )
+        message.document = document
+        message.answer = AsyncMock()
+
+        await handle_document(message, fsm_context)
+
+        data = await fsm_context.get_data()
+        assert len(data["files"]) == 1
+        assert data["files"][0]["file_extension"] == ".json"
+
+    @pytest.mark.asyncio
+    async def test_handle_document_no_file_size(self, message, fsm_context):
+        """Тест обработки файла без указания размера."""
+        document = Document(
+            file_id="test_file_id",
+            file_unique_id="test_unique_id",
+            file_name="export.json",
+            file_size=None,  # Размер не указан
+        )
+        message.document = document
+        message.answer = AsyncMock()
+
+        await handle_document(message, fsm_context)
+
+        # Файл должен быть принят, так как проверка размера пропускается при None
+        data = await fsm_context.get_data()
+        assert len(data["files"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_handle_document_no_file_name(self, message, fsm_context):
+        """Тест обработки файла без имени."""
+        document = Document(
+            file_id="test_file_id",
+            file_unique_id="test_unique_id",
+            file_name=None,  # Имя не указано
+            file_size=1024,
+        )
+        message.document = document
+        message.answer = AsyncMock()
+
+        await handle_document(message, fsm_context)
+
+        # Файл должен быть отклонен из-за отсутствия расширения
+        data = await fsm_context.get_data()
+        files = data.get("files", [])
+        assert len(files) == 0
+
+        message.answer.assert_called_once()
+        call_args = message.answer.call_args[0][0]
+        assert "❌ Неподдерживаемый формат файла" in call_args
+
+    @pytest.mark.asyncio
+    async def test_handle_document_state_preserved(self, message, document_json, fsm_context):
+        """Тест сохранения состояния при обработке нескольких файлов."""
+        # Устанавливаем состояние заранее
+        await fsm_context.set_state(UploadState.waiting_files)
+        await fsm_context.update_data(files=[])
+
+        message.document = document_json
+        message.answer = AsyncMock()
+        await handle_document(message, fsm_context)
+
+        # Проверяем, что состояние сохранилось
+        state = await fsm_context.get_state()
+        assert state == UploadState.waiting_files
+
+        data = await fsm_context.get_data()
+        assert len(data["files"]) == 1
+
+
+class TestCmdReset:
+    """Тесты для команды /reset."""
+
+    @pytest.mark.asyncio
+    async def test_cmd_reset_clears_state(self, message, fsm_context):
+        """Тест очистки состояния командой /reset."""
+        # Устанавливаем состояние и данные
+        await fsm_context.set_state(UploadState.waiting_files)
+        await fsm_context.update_data(files=[{"file_id": "test"}])
+
+        message.answer = AsyncMock()
+
+        # Вызываем команду
+        await cmd_reset(message, fsm_context)
+
+        # Проверяем, что состояние очищено
+        state = await fsm_context.get_state()
+        assert state is None
+
+        # Проверяем, что данные очищены
+        data = await fsm_context.get_data()
+        assert not data or "files" not in data
+
+        # Проверяем ответ
+        message.answer.assert_called_once()
+        call_args = message.answer.call_args[0][0]
+        assert "🔄 Очередь файлов очищена" in call_args
+
+    @pytest.mark.asyncio
+    async def test_cmd_reset_empty_state(self, message, fsm_context):
+        """Тест /reset при пустом состоянии."""
+        message.answer = AsyncMock()
+
+        await cmd_reset(message, fsm_context)
+
+        # Команда не должна падать
+        message.answer.assert_called_once()
+        call_args = message.answer.call_args[0][0]
+        assert "🔄 Очередь файлов очищена" in call_args
+
+    @pytest.mark.asyncio
+    async def test_cmd_reset_with_multiple_files(self, message, fsm_context):
+        """Тест /reset с несколькими файлами в очереди."""
+        # Добавляем несколько файлов
+        await fsm_context.set_state(UploadState.waiting_files)
+        await fsm_context.update_data(files=[
+            {"file_id": "file1"},
+            {"file_id": "file2"},
+            {"file_id": "file3"},
+        ])
+
+        message.answer = AsyncMock()
+
+        await cmd_reset(message, fsm_context)
+
+        # Проверяем, что все очищено
+        state = await fsm_context.get_state()
+        assert state is None
+
+        data = await fsm_context.get_data()
+        assert not data or "files" not in data
+


### PR DESCRIPTION
Добавлен файл `bot/states.py` с состоянием `UploadState` для реализации сценария загрузки файлов.  
Создан модуль `bot/handlers/files.py`, включающий обработчик документов и команду `/reset`.  
Реализована валидация файлов по размеру и расширению: разрешены только `.json`, `.html`, `.zip`.  
Настроено управление состояниями (FSM) для очереди загружаемых файлов.  
Добавлена команда `/reset` для сброса текущего состояния и очистки данных пользователя.  
Обновлен файл `bot/main.py`, подключив роутер из обработчиков файлов.  

(На всякий случай) написан полный набор тестов в каталоге `tests/test_files_handler.py`:  
- Проверку успешной обработки файлов форматов JSON, HTML, ZIP;  
- Проверку валидации по размеру и расширению;  
- Проверку обработки нескольких файлов подряд;  
- Проверку работы команды `/reset` (сброс состояния и данных).  

Добавлена конфигурация для `pytest` в файл `pytest.ini`.  
Включены зависимости для тестирования — `pytest` и `pytest-asyncio` — в файл `requirements.txt`.